### PR TITLE
Added missing StartupWMClass

### DIFF
--- a/cryptomator-ppa/debian/Cryptomator.desktop
+++ b/cryptomator-ppa/debian/Cryptomator.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 Categories=Utility;
 MimeType=application/x-vnd.cryptomator-vault-metadata
+StartupWMClass=org.cryptomator.launcher.Cryptomator$MainApp


### PR DESCRIPTION
This prevents an additional icon being opened in the GNOME dock when the application is pinned and it's opened, just as https://github.com/cryptomator/cryptomator-linux/pull/10 did. It also fixes https://github.com/cryptomator/cryptomator/issues/956.